### PR TITLE
[BUGFIX] replace call to non-existing function getCountExpression wit…

### DIFF
--- a/Classes/FormEngine/DownloadStatistics.php
+++ b/Classes/FormEngine/DownloadStatistics.php
@@ -51,9 +51,9 @@ class DownloadStatistics extends AbstractNode
         try {
             $statistics = $queryBuilder
                 ->selectLiteral(
-                    $queryBuilder->getConnection()->getDatabasePlatform()->getCountExpression(
-                        $queryBuilder->quoteIdentifier('tx_falsecuredownload_download.file')
-                    ) . ' AS ' . $queryBuilder->quoteIdentifier('cnt')
+                    'COUNT(' .
+                        $queryBuilder->quoteIdentifier('tx_falsecuredownload_download.file') .
+                    ') AS ' . $queryBuilder->quoteIdentifier('cnt')
                 )
                 ->addSelect('sys_file.name')
                 ->from('sys_file')


### PR DESCRIPTION
The method `AbstractPlatform->getCountExpression` which was already deprecated in doctrine/dbal v3.9 (TYPO3 12) has now been removed with doctrine/dbal v4 - see https://github.com/doctrine/dbal/blob/4.2.5/UPGRADE.md#bc-break-removed-redundant-abstractplatform-methods 

I replaced the function call with a fixed string as suggested in the deprecation warning: https://github.com/doctrine/dbal/blob/3.9.5/src/Platforms/AbstractPlatform.php#L808 